### PR TITLE
Add testable docs snippets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 integration-credentials.properties
+snippet-credentials.properties
 /.settings
 .classpath
 .project

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/integration-test/resources/example-data"]
+	path = src/integration-test/resources/example-data
+	url = git@github.com:TempoIQ/example-data.git

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
         <executions>
           <execution>
             <id>analyze-compile</id>
-            <phase>compile</phase>
+            <phase>verify</phase>
             <goals>
               <goal>check</goal>
             </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -39,38 +39,49 @@
     <integration-test.testSourceDirectory>${integration-test.directory}/java</integration-test.testSourceDirectory>
     <integration-test.docDirectory>${integration-test.directory}/resources</integration-test.docDirectory>
     <integration-test.testOutputDirectory>${project.build.directory}/integrationtest-classes</integration-test.testOutputDirectory>
+    <integration-test.include>**/*IT.java</integration-test.include>
   </properties>
 
   <profiles>
     <profile>
       <id>release-sign-artifacts</id>
       <activation>
-	<property>
-	  <name>performRelease</name>
-	  <value>true</value>
-	</property>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
       </activation>
       <build>
-	<plugins>
-	  <plugin>
-	    <groupId>org.apache.maven.plugins</groupId>
-	    <artifactId>maven-gpg-plugin</artifactId>
-	    <version>1.4</version>
-	    <configuration>
-	      <passphrase>${gpg.passphrase}</passphrase>
-	    </configuration>
-	    <executions>
-	      <execution>
-		<id>sign-artifacts</id>
-		<phase>verify</phase>
-		<goals>
-		  <goal>sign</goal>
-		</goals>
-	      </execution>
-	    </executions>
-	  </plugin>
-	</plugins>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.4</version>
+            <configuration>
+              <passphrase>${gpg.passphrase}</passphrase>
+            </configuration>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>snippets</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <properties>
+        <integration-test.include>**/Snippets.java</integration-test.include>
+      </properties>
     </profile>
   </profiles>
 
@@ -181,6 +192,11 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>2.16</version>
+        <configuration>
+          <includes>
+            <include>${integration-test.include}</include>
+          </includes>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -245,6 +245,7 @@ public class Snippets {
   public void testSinglePoint() {
     // snippet-begin single-point
     // import com.tempoiq.*;
+    // import org.joda.time.*;
 
     // select the sensor "temperature" in the device "thermostat.1"
     Selection selection = new Selection()
@@ -260,6 +261,27 @@ public class Snippets {
       System.out.format("ts: %s value: %f",
           row.getTimestamp(),
           row.getValue("thermostat.1", "temperature")).println();
+    }
+    // snippet-end
+  }
+
+  public void testDeleteDatapoints() {
+    // snippet-begin delete-data
+    // import com.tempoiq.*;
+    // import org.joda.time.*;
+    DateTime start = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
+    DateTime end = new DateTime(2015, 1, 1, 1, 0, 0, 0, DateTimeZone.UTC);
+
+    // delete datapoints for sensor "humidity" in device "thermostat.1"
+    // in the range [2015-01-01T00:00:00Z, 2015-01-01T01:00:00Z)
+    Device device = new Device("thermostat.1");
+    Sensor sensor = new Sensor("humidity");
+    Result<DeleteSummary> result = client.deleteDataPoints(device, sensor, start, end);
+
+    if(result.getState() == State.SUCCESS) {
+      System.out.format("Deleted %d datapoints", result.getValue().getDeleted()).println();
+    } else {
+      System.out.format("Error deleting datapoints! %s", result.getMessage()).println();
     }
     // snippet-end
   }

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -1,0 +1,137 @@
+package com.tempoiq;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+import org.joda.time.Period;
+
+import static com.tempoiq.util.Preconditions.*;
+
+
+public class Snippets {
+
+  private static final Client client;
+  private static final Client invalidClient;
+  private static final DateTimeZone timezone = DateTimeZone.UTC;
+  private static final DateTime start = new DateTime(1500, 1, 1, 0, 0, 0, 0, timezone);
+  private static final DateTime end = new DateTime(3000, 1, 1, 0, 0, 0, 0, timezone);
+  private static final Interval interval = new Interval(start, end);
+
+  static {
+    File credentials = new File("integration-credentials.properties");
+    if(!credentials.exists()) {
+      String message = "Missing credentials file for integration test.\n" +
+        "Please supply a file 'integration-credentials.properties' with the following format:\n" +
+        "  credentials.key=<key>\n" +
+        "  credentials.secret=<secret>\n" +
+        "  hostname=<hostname>\n" +
+        "  port=<port>\n" +
+        "  scheme=<scheme>\n";
+
+      System.err.print(message);
+    }
+    client = getClient(credentials);
+    invalidClient = new Client(new Credentials("key", "secret"),
+                               client.getHost(), client.getScheme());
+  }
+
+  static Client getcClient() {
+
+    // snippet-begin create-client
+    // import com.tempoiq.*;
+
+    InetSocketAddress host = new InetSocketAddress("my-company.backend.tempoiq.com", 443);
+    Credentials credentials = new Credentials("my-key", "my-secret");
+    Client client = new Client(credentials, host, "https");
+    // snippet-end
+    return client;
+  }
+
+  static Client getClient(File propertiesFile) {
+    Properties properties = new Properties();
+    try {
+      properties.load(new FileInputStream(propertiesFile));
+    } catch (Exception e) {
+      throw new IllegalArgumentException("No credentials file", e);
+    }
+
+    String key = checkNotNull(properties.getProperty("credentials.key"));
+    String secret = checkNotNull(properties.getProperty("credentials.secret"));
+    String hostname = checkNotNull(properties.getProperty("hostname"));
+    int port = Integer.parseInt(checkNotNull(properties.getProperty("port")));
+    String scheme = checkNotNull(properties.getProperty("scheme"));
+    Credentials credentials = new Credentials(key, secret);
+    InetSocketAddress host = new InetSocketAddress(hostname, port);
+    return new Client(credentials, host, scheme);
+  }
+
+  public void testCreateDevice() {
+    // snippet-begin create-device
+    // import java.util.*;
+    // import com.tempoiq.*;
+    // import org.joda.time.*;
+
+    // create device attributes
+    Map<String, String> attributes = new HashMap<String, String>();
+    attributes.put("model", "v1");
+
+    // create sensors
+    Sensor sensor1 = new Sensor("temperature");
+    Sensor sensor2 = new Sensor("humidity");
+    List<Sensor> sensors = new ArrayList<Sensor>();
+    sensors.addAll(Arrays.asList(sensor1, sensor2));
+
+    // create device with key "thermostat.0" with attributes and sensors
+    Device device = new Device("thermostat.0", "", attributes, sensors);
+
+    // store in TempoIQ
+    Result<Device> result = client.createDevice(device);
+
+    // Check that the request was successful
+    if(result.getState() != State.SUCCESS) {
+      System.out.println(String.format("Error creating device! %s", result.getMessage()));
+    }
+    // snippet-end
+  }
+
+  public void testWriteDataPoints() {
+    // snippet-begin write-data
+    // import java.util.*;
+    // import com.tempoiq.*;
+    // import org.joda.time.*;
+
+    // create datapoint at 2015-01-01T00:00:00.000Z for sensors temperature and humidity
+    DateTime dt1 = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
+    Map<String, Number> points1 = new HashMap<String, Number>();
+    points1.put("temperature", 68);
+    points1.put("humidity", 71.5);
+    MultiDataPoint mp1 = new MultiDataPoint(dt1, points1);
+
+    // create another datapoint, five minutes later, at 2015-01-01T00:05:00.000Z for sensors temperature and humidity
+    DateTime dt2 = dt1.plus(Period.minutes(5));
+    Map<String, Number> points2 = new HashMap<String, Number>();
+    points2.put("temperature", 67.5);
+    points2.put("humidity", 70.0);
+    MultiDataPoint mp2 = new MultiDataPoint(dt2, points2);
+
+    // Store datapoints in TempoIQ
+    Device device = new Device("thermostat.0");
+    Result<Void> result = client.writeDataPoints(device, Arrays.asList(mp1, mp2));
+
+    // Check that the request was successful
+    if(result.getState() != State.SUCCESS) {
+      System.out.println(String.format("Error writing data! %s", result.getMessage()));
+    }
+    // snippet-end
+  }
+}

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -134,4 +134,28 @@ public class Snippets {
     }
     // snippet-end
   }
+
+  public void testReadRawDataPoints() {
+    // snippet-begin read-data-one-device
+    // import java.util.*;
+    // import com.tempoiq.*;
+    // import org.joda.time.*;
+
+    // Set up the time range to read [2015-01-01, 2015-01-02)
+    DateTime start = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
+    DateTime end = new DateTime(2015, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC);
+
+    Device device = new Device("thermostat.0");
+    Selection selection = new Selection()
+      .addSelector(Selector.Type.DEVICES, Selector.key(device.getKey()));
+
+    Cursor<Row> cursor = client.read(selection, start, end);
+    for(Row row : cursor) {
+      System.out.println(String.format("timestamp %s, temperature: %f, humidity: %f",
+            row.getTimestamp(),
+            row.getValue("thermostat.0", "temperature"),
+            row.getValue("thermostat.0", "humidity")));
+    }
+    // snippet-end
+  }
 }

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -227,6 +227,8 @@ public class Snippets {
     Result<Device> create_result = client.createDevice(create);
 
     // snippet-begin delete-devices
+    // import com.tempoiq.*;
+
     Selection selection = new Selection()
       .addSelector(Selector.Type.DEVICES, Selector.key("thermostat.5"));
 
@@ -236,6 +238,28 @@ public class Snippets {
       System.out.format("Deleted %d devices.", result.getValue().getDeleted()).println();
     } else {
       System.out.format("Error deleting devices! %s", result.getMessage()).println();
+    }
+    // snippet-end
+  }
+
+  public void testSinglePoint() {
+    // snippet-begin single-point
+    // import com.tempoiq.*;
+
+    // select the sensor "temperature" in the device "thermostat.1"
+    Selection selection = new Selection()
+      .addSelector(Selector.Type.DEVICES, Selector.key("thermostat.1"))
+      .addSelector(Selector.Type.SENSORS, Selector.key("temperature"));
+
+    // get the first point before 2015-01-10T00:00:00.000Z
+    DateTime time = new DateTime(2015, 1, 10, 0, 0, 0, 0, DateTimeZone.UTC);
+    Single single = new Single(DirectionFunction.BEFORE, time);
+
+    Cursor<Row> cursor = client.single(selection, new Pipeline(), single);
+    for(Row row : cursor) {
+      System.out.format("ts: %s value: %f",
+          row.getTimestamp(),
+          row.getValue("thermostat.1", "temperature")).println();
     }
     // snippet-end
   }

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -285,4 +285,31 @@ public class Snippets {
     }
     // snippet-end
   }
+
+  public void testPipeline() {
+    // snippet-begin pipeline
+    // import com.tempoiq.*;
+    // import org.joda.time.*;
+
+    // Set up the time range to read [2015-01-01, 2015-01-02)
+    DateTime start = new DateTime(2015, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
+    DateTime end = new DateTime(2015, 1, 2, 0, 0, 0, 0, DateTimeZone.UTC);
+
+    // select device with key "thermostat.0"
+    Selection selection = new Selection()
+      .addSelector(Selector.Type.DEVICES, Selector.key("thermostat.0"));
+
+    // create a pipeline that calculates the hourly max
+    Pipeline pipeline = new Pipeline().rollup(Period.hours(1), Fold.MAX, start);
+
+    Cursor<Row> cursor = client.read(selection, pipeline, start, end);
+
+    for(Row row : cursor) {
+      System.out.format("timestamp %s, temperature: %f, humidity: %f",
+            row.getTimestamp(),
+            row.getValue("thermostat.0", "temperature"),
+            row.getValue("thermostat.0", "humidity")).println();
+    }
+    // snippet-end
+  }
 }

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -14,6 +14,8 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
 import org.joda.time.Period;
+import org.junit.*;
+import static org.junit.Assert.*;
 
 import static com.tempoiq.util.Preconditions.*;
 
@@ -28,10 +30,10 @@ public class Snippets {
   private static final Interval interval = new Interval(start, end);
 
   static {
-    File credentials = new File("integration-credentials.properties");
+    File credentials = new File("snippet-credentials.properties");
     if(!credentials.exists()) {
-      String message = "Missing credentials file for integration test.\n" +
-        "Please supply a file 'integration-credentials.properties' with the following format:\n" +
+      String message = "Missing credentials file for snippets.\n" +
+        "Please supply a file 'snippets-credentials.properties' with the following format:\n" +
         "  credentials.key=<key>\n" +
         "  credentials.secret=<secret>\n" +
         "  hostname=<hostname>\n" +
@@ -45,8 +47,7 @@ public class Snippets {
                                client.getHost(), client.getScheme());
   }
 
-  static Client getcClient() {
-
+  static Client getClient() {
     // snippet-begin create-client
     // import com.tempoiq.*;
 
@@ -75,6 +76,7 @@ public class Snippets {
     return new Client(credentials, host, scheme);
   }
 
+  @Test
   public void testCreateDevice() {
     // snippet-begin create-device
     // import java.util.*;
@@ -104,6 +106,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testWriteDataPoints() {
     // snippet-begin write-data
     // import java.util.*;
@@ -135,6 +138,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testReadRawDataPoints() {
     // snippet-begin read-data-one-device
     // import java.util.*;
@@ -159,6 +163,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testGetDevice() {
     // snippet-begin get-device
     // import com.tempoiq.*;
@@ -173,6 +178,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testGetDevices() {
     // snippet-begin get-devices
     // imoprt com.tempoiq.*;
@@ -197,6 +203,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testUpdateDevice() {
     // snippet-begin update-device
     // import com.tempoiq.*;
@@ -222,6 +229,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testDeleteDevices() {
     Device create = new Device("thermostat.5");
     Result<Device> create_result = client.createDevice(create);
@@ -242,6 +250,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testSinglePoint() {
     // snippet-begin single-point
     // import com.tempoiq.*;
@@ -265,6 +274,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testDeleteDatapoints() {
     // snippet-begin delete-data
     // import com.tempoiq.*;
@@ -286,6 +296,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testPipeline() {
     // snippet-begin pipeline
     // import com.tempoiq.*;
@@ -313,6 +324,7 @@ public class Snippets {
     // snippet-end
   }
 
+  @Test
   public void testSearch() {
     // snippet-begin search
     // import com.tempoiq.*;

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -99,7 +99,7 @@ public class Snippets {
 
     // Check that the request was successful
     if(result.getState() != State.SUCCESS) {
-      System.out.println(String.format("Error creating device! %s", result.getMessage()));
+      System.out.format("Error creating device! %s", result.getMessage()).println();
     }
     // snippet-end
   }
@@ -130,7 +130,7 @@ public class Snippets {
 
     // Check that the request was successful
     if(result.getState() != State.SUCCESS) {
-      System.out.println(String.format("Error writing data! %s", result.getMessage()));
+      System.out.format("Error writing data! %s", result.getMessage()).println();
     }
     // snippet-end
   }
@@ -151,35 +151,31 @@ public class Snippets {
 
     Cursor<Row> cursor = client.read(selection, start, end);
     for(Row row : cursor) {
-      System.out.println(String.format("timestamp %s, temperature: %f, humidity: %f",
+      System.out.format("timestamp %s, temperature: %f, humidity: %f",
             row.getTimestamp(),
             row.getValue("thermostat.0", "temperature"),
-            row.getValue("thermostat.0", "humidity")));
+            row.getValue("thermostat.0", "humidity")).println();
     }
     // snippet-end
   }
 
   public void testGetDevice() {
     // snippet-begin get-device
-    // import java.util.*;
     // import com.tempoiq.*;
-    // import org.joda.time.*;
 
     // get the device with key "thermostat.1"
     Result<Device> result = client.getDevice("thermostat.1");
 
     // Check that the request was successful
     if(result.getState() != State.SUCCESS) {
-      System.out.println(String.format("Error creating device! %s", result.getMessage()));
+      System.out.format("Error getting device! %s", result.getMessage()).println();
     }
     // snippet-end
   }
 
   public void testGetDevices() {
     // snippet-begin get-devices
-    // import java.util.*;
     // imoprt com.tempoiq.*;
-    // import org.joda.time.*;
 
     // create selection for all devices with attribute region in "south" or "east"
     Selection selection = new Selection()
@@ -193,10 +189,53 @@ public class Snippets {
     Cursor<Device> cursor = client.listDevices(selection);
 
     for(Device device : cursor) {
-      System.out.println(String.format("device: %s", device.getKey()));
+      System.out.format("device: %s", device.getKey()).println();
       for(Sensor sensor : device.getSensors()) {
-        System.out.println(String.format("\tsensor: %s", sensor.getKey()));
+        System.out.format("\tsensor: %s", sensor.getKey()).println();
       }
+    }
+    // snippet-end
+  }
+
+  public void testUpdateDevice() {
+    // snippet-begin update-device
+    // import com.tempoiq.*;
+
+    Result<Device> result = client.getDevice("thermostat.4");
+
+    // Check that the request was successful
+    if(result.getState() != State.SUCCESS) {
+      System.out.format("Error getting device! %s", result.getMessage()).println();
+    }
+
+    // mutate the device
+    Device device = result.getValue();
+    device.getAttributes().put("customer", "internal-test");
+    device.getAttributes().put("region", "east");
+
+    // update in TempoIQ
+    result = client.updateDevice(device);
+
+    if(result.getState() != State.SUCCESS) {
+      System.out.format("Error updating device! %s", result.getMessage()).println();
+    }
+    // snippet-end
+  }
+
+  public void testDeleteDevices() {
+    Device create = new Device("thermostat.5");
+    Result<Device> create_result = client.createDevice(create);
+
+    // snippet-begin delete-devices
+    Selection selection = new Selection()
+      .addSelector(Selector.Type.DEVICES, Selector.key("thermostat.5"));
+
+    Result<DeleteSummary> result = client.deleteDevices(selection);
+
+    if(result.getState() == State.SUCCESS) {
+      System.out.format("Deleted %d devices.", result.getValue().getDeleted()).println();
+    } else {
+      System.out.format("Error deleting devices! %s", result.getMessage()).println();
     }
     // snippet-end
   }

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -236,7 +236,7 @@ public class Snippets {
   @Test
   public void testDeleteDevices() {
     Device create = new Device("thermostat.5");
-    Result<Device> create_result = client.createDevice(create);
+    Result<Device> createdResult = client.createDevice(create);
 
     // snippet-begin delete-devices
     // import com.tempoiq.*;

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -104,6 +104,7 @@ public class Snippets {
       System.out.format("Error creating device! %s", result.getMessage()).println();
     }
     // snippet-end
+    assertEquals(State.SUCCESS, result.getState());
   }
 
   @Test
@@ -136,6 +137,7 @@ public class Snippets {
       System.out.format("Error writing data! %s", result.getMessage()).println();
     }
     // snippet-end
+    assertEquals(State.SUCCESS, result.getState());
   }
 
   @Test
@@ -176,6 +178,7 @@ public class Snippets {
       System.out.format("Error getting device! %s", result.getMessage()).println();
     }
     // snippet-end
+    assertEquals(State.SUCCESS, result.getState());
   }
 
   @Test
@@ -227,6 +230,7 @@ public class Snippets {
       System.out.format("Error updating device! %s", result.getMessage()).println();
     }
     // snippet-end
+    assertEquals(State.SUCCESS, result.getState());
   }
 
   @Test
@@ -248,6 +252,7 @@ public class Snippets {
       System.out.format("Error deleting devices! %s", result.getMessage()).println();
     }
     // snippet-end
+    assertEquals(State.SUCCESS, result.getState());
   }
 
   @Test
@@ -294,6 +299,7 @@ public class Snippets {
       System.out.format("Error deleting datapoints! %s", result.getMessage()).println();
     }
     // snippet-end
+    assertEquals(State.SUCCESS, result.getState());
   }
 
   @Test

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -159,6 +159,22 @@ public class Snippets {
     // snippet-end
   }
 
+  public void testGetDevice() {
+    // snippet-begin get-device
+    // import java.util.*;
+    // import com.tempoiq.*;
+    // import org.joda.time.*;
+
+    // get the device with key "thermostat.1"
+    Result<Device> result = client.getDevice("thermostat.1");
+
+    // Check that the request was successful
+    if(result.getState() != State.SUCCESS) {
+      System.out.println(String.format("Error creating device! %s", result.getMessage()));
+    }
+    // snippet-end
+  }
+
   public void testGetDevices() {
     // snippet-begin get-devices
     // import java.util.*;

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -312,4 +312,14 @@ public class Snippets {
     }
     // snippet-end
   }
+
+  public void testSearch() {
+    // snippet-begin search
+    // import com.tempoiq.*;
+
+    Selection selection = new Selection()
+      .addSelector(Selector.Type.DEVICES, Selector.attributes("building", "headquarters"))
+      .addSelector(Selector.Type.SENSORS, Selector.key("temperature"));
+    // snippet-end
+  }
 }

--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -158,4 +158,30 @@ public class Snippets {
     }
     // snippet-end
   }
+
+  public void testGetDevices() {
+    // snippet-begin get-devices
+    // import java.util.*;
+    // imoprt com.tempoiq.*;
+    // import org.joda.time.*;
+
+    // create selection for all devices with attribute region in "south" or "east"
+    Selection selection = new Selection()
+      .addSelector(Selector.Type.DEVICES,
+          Selector.or(
+            Selector.attributes("region", "south"),
+            Selector.attributes("region", "east")
+          )
+      );
+
+    Cursor<Device> cursor = client.listDevices(selection);
+
+    for(Device device : cursor) {
+      System.out.println(String.format("device: %s", device.getKey()));
+      for(Sensor sensor : device.getSensors()) {
+        System.out.println(String.format("\tsensor: %s", sensor.getKey()));
+      }
+    }
+    // snippet-end
+  }
 }

--- a/src/scripts/run-snippets
+++ b/src/scripts/run-snippets
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "$0" )" && pwd )
+BASE_DIR=${DIR%%/}/../../
+INSTALL_DIR=${BASE_DIR%%/}/src/integration-test/resources/example-data/
+INSTALL_SCRIPT=${INSTALL_DIR}initialize.py
+usage="Usage: $(basename "$0") -k <api-key> -s <api-secret> -n <hostname>
+
+Options:
+  -k        api key
+  -s        api secret
+  -n        backend hostname (with scheme)
+  -h        print this help message"
+
+while getopts ":hk:n:s:" opt; do
+  case $opt in
+    k) key="$OPTARG"
+       ;;
+    s) secret="$OPTARG"
+       ;;
+    n) host="$OPTARG"
+       ;;
+    h) echo "$usage"
+       exit
+       ;;
+    :) echo "missing argument for -$OPTARG"
+       echo "$usage" >&2
+       exit 1
+       ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+        echo "$usage" >&2
+        exit 1
+    ;;
+  esac
+done
+
+
+shift $(($OPTIND - 1))
+
+if [ -z ${key+x} ]
+then
+    echo "-k must be used to supply api key" >&2
+    echo "$usage"
+    exit 1
+fi
+
+if [ -z ${secret+x} ]
+then
+    echo "-s must be used to supply api secret" >&2
+    echo "$usage"
+    exit 1
+fi
+
+if [ -z ${host+x} ]
+then
+    echo "-n must be used to supply backend hostname" >&2
+    echo "$usage"
+    exit 1
+fi
+
+cd $INSTALL_DIR && python $INSTALL_SCRIPT -k $key -s $secret -n $host
+cd $BASE_DIR && mvn verify -Psnippets

--- a/src/scripts/run-snippets
+++ b/src/scripts/run-snippets
@@ -58,5 +58,8 @@ then
     exit 1
 fi
 
+echo "Loading example data"
 cd $INSTALL_DIR && python $INSTALL_SCRIPT -k $key -s $secret -n $host
+
+echo "Running snippets tests"
 cd $BASE_DIR && mvn verify -Psnippets


### PR DESCRIPTION
To test the snippets, create a `snippet-credentials.properties`, similar to the integration tests. Run the `run-snippets` script to load the example data and run the tests.

:warning: Don't run this on a production database. The load script deletes data and creates new devices/datapoints in the backend.