### PR TITLE
Rename UpsertResponse to WriteResponse

### DIFF
--- a/src/integration-test/java/com/tempoiq/ClientIT.java
+++ b/src/integration-test/java/com/tempoiq/ClientIT.java
@@ -126,7 +126,7 @@ public class ClientIT {
     points.put("sensor1", 1.23);
     points.put("sensor2", 1.67);
     MultiDataPoint mp = new MultiDataPoint(new DateTime(2012, 1, 1, 0, 0, 0, 0, timezone), points);
-    Result<UpsertResponse> result = client.writeDataPoints(device, mp);
+    Result<WriteResponse> result = client.writeDataPoints(device, mp);
     assertEquals(State.SUCCESS, result.getState());
   }
 
@@ -141,7 +141,7 @@ public class ClientIT {
       points.put("sensor1", i+0.1);
       points.put("sensor2", i+10.1);
       MultiDataPoint mp = new MultiDataPoint(new DateTime(2012, i, 1, 1, 0, 0, 0, timezone), points);
-      Result<UpsertResponse> result = client.writeDataPoints(device, mp);
+      Result<WriteResponse> result = client.writeDataPoints(device, mp);
       assertEquals(State.SUCCESS, result.getState());
     }
     Selection sel = new Selection().addSelector(Selector.Type.DEVICES, Selector.key(device.getKey()));
@@ -169,7 +169,7 @@ public class ClientIT {
     allPoints.add(mp);
     allPoints.add(mp2);
 
-    Result<UpsertResponse> result = client.writeDataPoints(device, allPoints);
+    Result<WriteResponse> result = client.writeDataPoints(device, allPoints);
     assertEquals(State.SUCCESS, result.getState());
 
     Selection sel = new Selection().
@@ -201,7 +201,7 @@ public class ClientIT {
     }
 
     for(MultiDataPoint mp : mps) {
-      Result<UpsertResponse> result = client.writeDataPoints(device, mp);
+      Result<WriteResponse> result = client.writeDataPoints(device, mp);
       assertEquals(State.SUCCESS, result.getState());
     }
 
@@ -230,7 +230,7 @@ public class ClientIT {
     allPoints.add(mp);
     allPoints.add(mp2);
 
-    Result<UpsertResponse> result = client.writeDataPoints(device, allPoints);
+    Result<WriteResponse> result = client.writeDataPoints(device, allPoints);
     assertEquals(State.SUCCESS, result.getState());
 
     Selection sel = new Selection().addSelector(Selector.Type.DEVICES, Selector.key(device.getKey()));
@@ -256,7 +256,7 @@ public class ClientIT {
     allPoints.add(mp);
     allPoints.add(mp2);
 
-    Result<UpsertResponse> result = client.writeDataPoints(device, allPoints);
+    Result<WriteResponse> result = client.writeDataPoints(device, allPoints);
     assertEquals(State.SUCCESS, result.getState());
 
     Selection sel = new Selection().addSelector(Selector.Type.DEVICES, Selector.key(device.getKey()));
@@ -282,7 +282,7 @@ public class ClientIT {
     allPoints.add(mp);
     allPoints.add(mp2);
 
-    Result<UpsertResponse> result = client.writeDataPoints(device, allPoints);
+    Result<WriteResponse> result = client.writeDataPoints(device, allPoints);
     assertEquals(State.SUCCESS, result.getState());
 
     Selection sel = new Selection().addSelector(Selector.Type.DEVICES, Selector.key(device.getKey()));
@@ -322,7 +322,7 @@ public class ClientIT {
     allPoints.add(mp2);
     allPoints.add(mp3);
 
-    Result<UpsertResponse> result = client.writeDataPoints(device, allPoints);
+    Result<WriteResponse> result = client.writeDataPoints(device, allPoints);
     assertEquals(State.SUCCESS, result.getState());
 
     DateTime start = new DateTime(2012, 1, 1, 2, 0, 0, 0, timezone);

--- a/src/main/java/com/tempoiq/Client.java
+++ b/src/main/java/com/tempoiq/Client.java
@@ -259,7 +259,7 @@ public class Client {
     return runner.delete(uri, body, contentType, mediaTypes);
   }
 
-  public Result<UpsertResponse> writeDataPoints(Device device, MultiDataPoint data) {
+  public Result<WriteResponse> writeDataPoints(Device device, MultiDataPoint data) {
     checkNotNull(device);
     checkNotNull(data);
 
@@ -271,7 +271,7 @@ public class Client {
     return writeDataPoints(wr);
   }
 
-  public Result<UpsertResponse> writeDataPoints(Device device, List<MultiDataPoint> data) {
+  public Result<WriteResponse> writeDataPoints(Device device, List<MultiDataPoint> data) {
     checkNotNull(device);
     checkNotNull(data);
     WriteRequest wr = new WriteRequest();
@@ -287,17 +287,17 @@ public class Client {
    *  Writes datapoints to multiple Devices and Sensor.
    *
    *  <p>This request can partially succeed. You should check the {@link Result#getState()} to check if the request was
-   *  successful. If the request was partially successful, the result's {@link UpsertResponse} can be inspected to determine
+   *  successful. If the request was partially successful, the result's {@link WriteResponse} can be inspected to determine
    *  what failed.
    *
    *  @param request A WriteRequest for the DataPoints to write.
-   *  @return {@link UpsertResponse}
+   *  @return {@link WriteResponse}
    *
    *  @see MultiDataPoint
-   *  @see UpsertResponse
+   *  @see WriteResponse
    *  @since 1.0.0
    */
-  public Result<UpsertResponse> writeDataPoints(WriteRequest request) {
+  public Result<WriteResponse> writeDataPoints(WriteRequest request) {
     checkNotNull(request);
     String contentType = mediaType("write-request", "v1");
     String[] mediaTypes = new String[] { mediaType("error", "v1") };
@@ -311,17 +311,17 @@ public class Client {
       throw new IllegalArgumentException(message, e);
     }
 
-    Result<UpsertResponse> result = null;
+    Result<WriteResponse> result = null;
     String body = null;
     try {
       body = Json.dumps(request.asMap());
     } catch (JsonProcessingException e) {
       String message = "Error serializing the body of the request. More detail: " + e.getMessage();
-      result = new Result<UpsertResponse>(null, GENERIC_ERROR_CODE, message);
+      result = new Result<WriteResponse>(null, GENERIC_ERROR_CODE, message);
       return result;
     }
 
-    return runner.post(uri, body, UpsertResponse.class, contentType, mediaTypes);
+    return runner.post(uri, body, WriteResponse.class, contentType, mediaTypes);
   }
 
   public DeviceCursor listDevices(Selection selection) {

--- a/src/main/java/com/tempoiq/WriteResponse.java
+++ b/src/main/java/com/tempoiq/WriteResponse.java
@@ -12,10 +12,10 @@ import org.apache.http.HttpEntity;
 import org.apache.http.util.EntityUtils;
 import com.tempoiq.json.Json;
 
-public class UpsertResponse {
+public class WriteResponse {
   private HashMap<String, DeviceStatus> statuses;
 
-  public UpsertResponse(HashMap<String, DeviceStatus> response) {
+  public WriteResponse(HashMap<String, DeviceStatus> response) {
     this.statuses = response;
   }
 
@@ -71,13 +71,13 @@ public class UpsertResponse {
     return results;
   }
   
-  public static UpsertResponse make(HttpResponse response) throws java.io.IOException {
+  public static WriteResponse make(HttpResponse response) throws java.io.IOException {
     HttpEntity entity = response.getEntity();
     String responseString = EntityUtils.toString(entity, "UTF-8");
     if (responseString.isEmpty()) {
       responseString = "{}";
     }
-    UpsertResponse data = Json.loads(responseString, UpsertResponse.class);
+    WriteResponse data = Json.loads(responseString, WriteResponse.class);
     return data; 
   }
 
@@ -92,9 +92,9 @@ public class UpsertResponse {
   public boolean equals(Object obj) {
     if(obj == null) return false;
     if(obj == this) return true;
-    if(!(obj instanceof UpsertResponse)) return false;
+    if(!(obj instanceof WriteResponse)) return false;
 
-    UpsertResponse rhs = (UpsertResponse)obj;
+    WriteResponse rhs = (WriteResponse)obj;
     return new EqualsBuilder()
       .append(statuses, rhs.statuses)
       .isEquals();

--- a/src/main/java/com/tempoiq/json/Json.java
+++ b/src/main/java/com/tempoiq/json/Json.java
@@ -34,7 +34,7 @@ public class Json {
       _mapper.registerModule(new WriteRequestModule());
       _mapper.registerModule(new DirectionFunctionModule());
       _mapper.registerModule(new DeviceStateModule()); 
-      _mapper.registerModule(new UpsertResponseModule()); 
+      _mapper.registerModule(new WriteResponseModule()); 
       _mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
       _mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
       mapper = _mapper;

--- a/src/main/java/com/tempoiq/json/WriteResponseModule.java
+++ b/src/main/java/com/tempoiq/json/WriteResponseModule.java
@@ -16,21 +16,21 @@ import com.fasterxml.jackson.databind.deser.std.StdScalarDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.ser.std.StdScalarSerializer;
 import com.tempoiq.DeviceStatus;
-import com.tempoiq.UpsertResponse;
+import com.tempoiq.WriteResponse;
 
-public class UpsertResponseModule extends SimpleModule {
-  public UpsertResponseModule() {
-    addDeserializer(UpsertResponse.class, new UpsertResponseDeserializer());
+public class WriteResponseModule extends SimpleModule {
+  public WriteResponseModule() {
+    addDeserializer(WriteResponse.class, new WriteResponseDeserializer());
   }
 
-  private static class UpsertResponseDeserializer extends StdScalarDeserializer<UpsertResponse> {
+  private static class WriteResponseDeserializer extends StdScalarDeserializer<WriteResponse> {
 
-    public UpsertResponseDeserializer() {
-      super(UpsertResponse.class);
+    public WriteResponseDeserializer() {
+      super(WriteResponse.class);
     }
 
     @Override
-    public UpsertResponse deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+    public WriteResponse deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
       JsonNode node = jp.readValueAsTree(); 
       Iterator<String> fields = node.fieldNames();
       HashMap<String, DeviceStatus> statuses = new HashMap<String, DeviceStatus>();
@@ -39,7 +39,7 @@ public class UpsertResponseModule extends SimpleModule {
         DeviceStatus status = Json.getObjectMapper().treeToValue(node.get(key), DeviceStatus.class);
         statuses.put(key, status);
       }
-      return new UpsertResponse(statuses);
+      return new WriteResponse(statuses);
     }
   }
 

--- a/src/test/java/com/tempoiq/ResultTest.java
+++ b/src/test/java/com/tempoiq/ResultTest.java
@@ -67,11 +67,11 @@ public class ResultTest {
   @Test
   public void testPartialFailure() throws IOException {
     String json = "{\"device-1\": {\"device_state\": \"modified\", \"message\": null, \"success\": true}}";
-    UpsertResponse resp = Json.loads(json, UpsertResponse.class);
+    WriteResponse resp = Json.loads(json, WriteResponse.class);
     HttpResponse response = Util.getResponse(207, json);
-    Result<UpsertResponse> result = new Result<UpsertResponse>(response, UpsertResponse.class);
+    Result<WriteResponse> result = new Result<WriteResponse>(response, WriteResponse.class);
 
-    Result<UpsertResponse> expected = new Result<UpsertResponse>(resp, 207, "Multi-Status"); 
+    Result<WriteResponse> expected = new Result<WriteResponse>(resp, 207, "Multi-Status"); 
     assertEquals(expected, result);
     assertTrue(result.getState() == State.PARTIAL_SUCCESS);
   }
@@ -80,10 +80,10 @@ public class ResultTest {
   public void testUpsertNoBody() throws IOException {
     String json = "";
     HttpResponse response = Util.getResponse(200, json);
-    UpsertResponse resp = new UpsertResponse(new HashMap<String, DeviceStatus>());
-    Result<UpsertResponse> result = new Result<UpsertResponse>(response, UpsertResponse.class);
+    WriteResponse resp = new WriteResponse(new HashMap<String, DeviceStatus>());
+    Result<WriteResponse> result = new Result<WriteResponse>(response, WriteResponse.class);
 
-    Result<UpsertResponse> expected = new Result<UpsertResponse>(resp, 200, "OK");
+    Result<WriteResponse> expected = new Result<WriteResponse>(resp, 200, "OK");
     assertEquals(expected, result);
     assertTrue(result.getState() == State.SUCCESS);
   }

--- a/src/test/java/com/tempoiq/WriteDataPointsTest.java
+++ b/src/test/java/com/tempoiq/WriteDataPointsTest.java
@@ -37,12 +37,12 @@ public class WriteDataPointsTest {
 
   @Test
   public void smokeTest() throws IOException {
-    UpsertResponse resp = Json.loads(multistatus_json, UpsertResponse.class);
+    WriteResponse resp = Json.loads(multistatus_json, WriteResponse.class);
     HttpResponse response = Util.getResponse(200, multistatus_json);
     Client client = Util.getClient(response);
-    Result<UpsertResponse> result = client.writeDataPoints(wr);
+    Result<WriteResponse> result = client.writeDataPoints(wr);
     
-    Result<UpsertResponse> expected = new Result<UpsertResponse>(resp, 200, "OK");
+    Result<WriteResponse> expected = new Result<WriteResponse>(resp, 200, "OK");
     assertEquals(expected, result);
     assertEquals("OK", result.getMessage());
   }
@@ -53,7 +53,7 @@ public class WriteDataPointsTest {
     HttpClient mockClient = Util.getMockHttpClient(response);
     Client client = Util.getClient(mockClient);
 
-    Result<UpsertResponse> result = client.writeDataPoints(wr);
+    Result<WriteResponse> result = client.writeDataPoints(wr);
 
     HttpRequest request = Util.captureRequest(mockClient);
     assertEquals("POST", request.getRequestLine().getMethod());
@@ -65,7 +65,7 @@ public class WriteDataPointsTest {
     HttpClient mockClient = Util.getMockHttpClient(response);
     Client client = Util.getClient(mockClient);
 
-    Result<UpsertResponse> result = client.writeDataPoints(wr);
+    Result<WriteResponse> result = client.writeDataPoints(wr);
 
     HttpRequest request = Util.captureRequest(mockClient);
     URI uri = new URI(request.getRequestLine().getUri());
@@ -78,7 +78,7 @@ public class WriteDataPointsTest {
     HttpClient mockClient = Util.getMockHttpClient(response);
     Client client = Util.getClient(mockClient);
 
-    Result<UpsertResponse> result = client.writeDataPoints(wr);
+    Result<WriteResponse> result = client.writeDataPoints(wr);
 
     ArgumentCaptor<HttpPost> argument = ArgumentCaptor.forClass(HttpPost.class);
     verify(mockClient).execute(any(HttpHost.class), argument.capture(), any(HttpContext.class));
@@ -86,14 +86,14 @@ public class WriteDataPointsTest {
   }
 
   @Test
-  public void testUpsertResponse() throws IOException {
-    UpsertResponse resp = Json.loads(multistatus_json, UpsertResponse.class);
+  public void testWriteResponse() throws IOException {
+    WriteResponse resp = Json.loads(multistatus_json, WriteResponse.class);
     HttpResponse response = Util.getResponse(207, multistatus_json);
     Client client = Util.getClient(response);
 
-    Result<UpsertResponse> result = client.writeDataPoints(wr);
+    Result<WriteResponse> result = client.writeDataPoints(wr);
 
-    Result<UpsertResponse> expected = new Result<UpsertResponse>(resp, 207, "Multi-Status");
+    Result<WriteResponse> expected = new Result<WriteResponse>(resp, 207, "Multi-Status");
     assertEquals(expected, result);
   }
 }


### PR DESCRIPTION
After this PR, we should be able to take the upsert branch to master.

Ran: Unit tests, and Upsert spreadsheet tests:

```
Writing to existing sensor / device: MV30: SUCCESS, value: com.tempoiq.WriteResponse@275
Writing to existing sensor / device: MV43: SUCCESS, value: com.tempoiq.WriteResponse@8dcd5a67
Writing to nonexisting sensor: MV30: PARTIAL_SUCCESS, value: com.tempoiq.WriteResponse@7456c706
Writing to nonexisting sensor: MV43: SUCCESS, value: com.tempoiq.WriteResponse@32c73b4f
Writing to nonexisting device: MV30: FAILURE, value: null
Writing to nonexisting device: MV43: SUCCESS, value: com.tempoiq.WriteResponse@b725ee56
Partial Success One: MV30: FAILURE, value: null
Partial Success One: MV43: SUCCESS, value: com.tempoiq.WriteResponse@481b5cb2
Partial Success Two: MV30: PARTIAL_SUCCESS, value: com.tempoiq.WriteResponse@96e817d3
Partial Success Two: MV43: SUCCESS, value: com.tempoiq.WriteResponse@d507a8c0
```