### PR TITLE
Multistatus investigation

### DIFF
--- a/src/integration-test/java/com/tempoiq/Snippets.java
+++ b/src/integration-test/java/com/tempoiq/Snippets.java
@@ -130,7 +130,7 @@ public class Snippets {
 
     // Store datapoints in TempoIQ
     Device device = new Device("thermostat.0");
-    Result<Void> result = client.writeDataPoints(device, Arrays.asList(mp1, mp2));
+    Result<WriteResponse> result = client.writeDataPoints(device, Arrays.asList(mp1, mp2));
 
     // Check that the request was successful
     if(result.getState() != State.SUCCESS) {

--- a/src/main/java/com/tempoiq/Executor.java
+++ b/src/main/java/com/tempoiq/Executor.java
@@ -107,22 +107,19 @@ public class Executor {
   }
 
   <T> Result<T> execute(HttpRequest request, Class<T> klass) {
-    Result<T> result = null;
     try {
       HttpResponse response = executeRequest(request);
-      result = new Result<T>(response, klass);
+      return new Result<T>(response, klass);
     } catch (IOException e) {
-      result = new Result<T>(null, GENERIC_ERROR_CODE, e.getMessage());
+      return new Result<T>(null, GENERIC_ERROR_CODE, e.getMessage());
     }
-    return result;
   }
 
   HttpResponse executeRequest(HttpRequest request) throws IOException {
     HttpClient client = getHttpClient();
     HttpContext context = getContext();
     HttpHost target = getTarget();
-    HttpResponse response = client.execute(target, request, context);
-    return response;
+    return client.execute(target, request, context);
   }
 
   HttpRequest buildRequest(URI uri, HttpMethod method, String body, String contentType, String[] mediaTypes) {


### PR DESCRIPTION
( https://tempoiq.atlassian.net/browse/BACKEND-613 )
It looks to me like the original problem (quoted below) was actually solved several commits back. For support: the class `MultiStatus` has been renamed twice (`WriteResponse`, currently), and there's a test in .../tempoiq-java/src/test/java/com/tempoiq/ResultTest.java for a partial failure that should fail in the case mentioned in the ticket. There was a bug in the Snippets.java file that kept `mvn test` from running, and I made a few stylistic touch-ups while I was poking around, though.
